### PR TITLE
Support numeric hex colors for languages like JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,6 @@ Array of fields not to display. Overrides `colorInfo.fields`. If you only need t
 #### `colorInfo.languages`
 Defines which files and languages have color info enabled, and which color types are supported.
 
-The default language setting enables all color values for the following file types:
-
-* `css` - CSS stylesheets
-* `sass` - Sass stylesheets
-* `less` - LESS stylesheets
-* `js` - JavaScript
-* `ts` - TypeScript
-* `cs` - C#
-* `java` - Java
-
 Each element consists of:
 
 * `"selector"` - [VSCode document selector](https://code.visualstudio.com/Docs/extensionAPI/vscode-api#DocumentSelector).
@@ -67,6 +57,16 @@ Each element consists of:
     * `rgb` - Css rgb or rgba (`rgb(1, 2, 3)` or `rgba(1, 2, 3, 0.5)`) 
     * `hsl` - Css hsl or hsla (`hsl(1, 2, 3)` or  `hsla(1, 2, 3, 0.5)`)
     * `css-colors-names` - Css color names (`red`, `blue`)
+
+The default language setting enables all color values for the following file types:
+
+* `css` - CSS stylesheets
+* `sass` - Sass stylesheets
+* `less` - LESS stylesheets
+* `js` - JavaScript
+* `ts` - TypeScript
+* `cs` - C#
+* `java` - Java
 
 VSCode does not currently support nested languages, so to enable Color Info in an `html` file, you must add:
 

--- a/README.md
+++ b/README.md
@@ -42,25 +42,17 @@ Array of fields not to display. Overrides `colorInfo.fields`. If you only need t
 
 
 #### `colorInfo.languages`
-Defines which files and languages have color info enabled, and which color types are supported. The default language setting enables all css color values for `css`, `sass`, and `less` documents:
+Defines which files and languages have color info enabled, and which color types are supported.
 
-```json
-"colorInfo.languages": [
-    {
-        "selector": "css",
-        "colors": "css"
-    }, {
-        "selector": "sass",
-        "colors": "css"
-    }, {
-        "selector": "scss",
-        "colors": "css"
-    }, {
-        "selector": "less",
-        "colors": "css"
-    }
-]
-```
+The default language setting enables all color values for the following file types:
+
+* `css` - CSS stylesheets
+* `sass` - Sass stylesheets
+* `less` - LESS stylesheets
+* `js` - JavaScript
+* `ts` - TypeScript
+* `cs` - C#
+* `java` - Java
 
 Each element consists of:
 
@@ -70,7 +62,9 @@ Each element consists of:
     * `css` - All css color value types
     * `hex` - Css hex (`#ff00ff` or `#f0f`)
     * `hex+alpha` - Css hex plus alpha (`#ff00ff77` or `#f0f7`)
-    * `rgb` - Css rgb or rgba (`rgb(1, 2, 3)` or `rgba(1, 2, 3, 0.5)`) c
+    * `numhex` - Numeric hex (`0xFFAABB`)
+    * `numhex+alpha` - Numeric hex plus alpha (`0xFFAABBEE`)
+    * `rgb` - Css rgb or rgba (`rgb(1, 2, 3)` or `rgba(1, 2, 3, 0.5)`) 
     * `hsl` - Css hsl or hsla (`hsl(1, 2, 3)` or  `hsla(1, 2, 3, 0.5)`)
     * `css-colors-names` - Css color names (`red`, `blue`)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VSCode Color Info
 
-[Visual Studio Code](https://code.visualstudio.com) extension that provides quick information css colors.
+[Visual Studio Code](https://code.visualstudio.com) extension that provides quick information of colors in any programming language.
 
 ![fields](media/starter-example.png)
 

--- a/README.md
+++ b/README.md
@@ -63,18 +63,8 @@ The default language setting enables all color values for the following file typ
 * `css` - CSS stylesheets
 * `sass` - Sass stylesheets
 * `less` - LESS stylesheets
+* `html` - HTML templates
 * `js` - JavaScript
 * `ts` - TypeScript
 * `cs` - C#
 * `java` - Java
-
-VSCode does not currently support nested languages, so to enable Color Info in an `html` file, you must add:
-
-```json
-{
-    "selector": "html",
-    "colors": "css"
-}
-```
-
-To your `colorInfo.languages` setting. Make you add this setting to the end of the default `colorInfo.languages` setting so that you do not disable Color Info for the standard languages.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "color-info",
   "displayName": "Color Info",
-  "description": "Provides quick information about css colors",
+  "description": "Provides quick information about colors in any programming language",
   "version": "0.7.2",
   "publisher": "bierner",
   "license": "MIT",
@@ -110,7 +110,35 @@
             {
               "selector": "less",
               "colors": "css"
-            }
+            },
+		        {
+		        	"selector": "js",
+		        	"colors": [
+		        		"numhex",
+		        		"numhex+alpha"
+		        	]
+		        },
+		        {
+		        	"selector": "ts",
+		        	"colors": [
+		        		"numhex",
+		        		"numhex+alpha"
+		        	]
+		        },
+		        {
+		        	"selector": "cs",
+		        	"colors": [
+		        		"numhex",
+		        		"numhex+alpha"
+		        	]
+		        },
+		        {
+		        	"selector": "java",
+		        	"colors": [
+		        		"numhex",
+		        		"numhex+alpha"
+		        	]
+		        }
           ],
           "items": {
             "type": "object",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,10 @@
               "selector": "less",
               "colors": "css"
             },
+            {
+              "selector": "html",
+              "colors": "css"
+            },
 		        {
 		        	"selector": "js",
 		        	"colors": [

--- a/src/color_extractor.ts
+++ b/src/color_extractor.ts
@@ -84,6 +84,26 @@ const hexaExtractor: ColorValueExtractor = {
 };
 
 /**
+ * Get all numeric hex colors in a line of text.
+ */
+const numHexExtractor: ColorValueExtractor = {
+    type: 'numhex',
+    getColors(line: string, position: vscode.Position) {
+        return getRegExForLine(/(?:^|\s|\W)(0x(?:[0-9a-fA-F]{3}){1,2})(\b|$)/g, line, position.line);
+    },
+};
+
+/**
+ * Get all numeric hex colors with alpha in a line of text.
+ */
+const numHexaExtractor: ColorValueExtractor = {
+    type: 'numhex+alpha',
+    getColors(line: string, position: vscode.Position) {
+        return getRegExForLine(/(?:^|\s|\W)(0x(?:[0-9a-fA-F]{4}){1,2})(\b|$)/g, line, position.line);
+    },
+};
+
+/**
  * Extracts named css colors
  */
 const cssNameExtractor: ColorValueExtractor = {
@@ -143,6 +163,8 @@ const valueExtractorRegistry = [
     hexExtractor,
     hexaExtractor,
     cssNameExtractor,
+    numHexExtractor,
+    numHexaExtractor
 ].reduce((registry, extractor) => {
     registry[extractor.type] = extractor;
     return registry;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,8 +19,6 @@ class LanguageConfiguration {
                     types.add('hex');
                     types.add('hex+alpha');
                     types.add('css-color-names');
-                    types.add('numhex');
-                    types.add('numhex+alpha');
                     break;
                 case 'rgb':
                 case 'hsl':

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,12 +19,16 @@ class LanguageConfiguration {
                     types.add('hex');
                     types.add('hex+alpha');
                     types.add('css-color-names');
+                    types.add('numhex');
+                    types.add('numhex+alpha');
                     break;
                 case 'rgb':
                 case 'hsl':
                 case 'hex':
                 case 'hex+alpha':
                 case 'css-color-names':
+                case 'numhex':
+                case 'numhex+alpha':
                     types.add(t);
                     break;
             }


### PR DESCRIPTION
Hi there.

This is my first PR, I hope its okay.

I wanted to add support for numeric hex colors like `0xFFAABB` or `0xFFFFAABB` seen in languages like JavaScript, TypeScript, and others.

I've tested the Regex in a regex tool and it works.

**Changes:**

1. Add support for numeric hex colors using `numhex` and `numhex+alpha` tags
3. Add smart defaults in the extension settings for various common web programming files (HTML, JS, TS, CS, Java)
4. Update the readme based on these ([preview here](https://github.com/robinrodricks/vscode-color-info#colorinfolanguages))
